### PR TITLE
Feat/11 jwt security config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,12 +58,16 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     // test
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.kafka:spring-kafka-test'
     testImplementation 'org.mockito:mockito-core:4.8.0'
 
     // dotenv
     implementation 'io.github.cdimascio:dotenv-java:3.2.0'
+
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
 }
 

--- a/src/main/java/com/example/emergencyassistb4b4/auth/dto/TokenResponseDto.java
+++ b/src/main/java/com/example/emergencyassistb4b4/auth/dto/TokenResponseDto.java
@@ -1,0 +1,3 @@
+package com.example.emergencyassistb4b4.auth.dto;
+
+public record TokenResponseDto(String accessToken, String refreshToken) {}

--- a/src/main/java/com/example/emergencyassistb4b4/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/example/emergencyassistb4b4/auth/service/RefreshTokenService.java
@@ -1,0 +1,34 @@
+package com.example.emergencyassistb4b4.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@RequiredArgsConstructor
+@Service
+public class RefreshTokenService { // Refresh 토큰을 저장/조회/삭제 ( RedisTemplate 을 사용 )
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private static final long REFRESH_TOKEN_EXPIRE = 60 * 60 * 24 * 7;
+
+    public void saveToken(Long userId, String refreshToken) {
+        redisTemplate.opsForValue().set(
+                getKey(userId),
+                refreshToken,
+                Duration.ofSeconds(REFRESH_TOKEN_EXPIRE));
+    }
+
+    private String getKey(Long userId) {
+        return "refresh_token:" + userId;
+    }
+
+    public String getRefreshToken(Long userId) {
+        return (String) redisTemplate.opsForValue().get(getKey(userId));
+    }
+
+    public void deleteRefreshToken(Long userId) {
+        redisTemplate.delete(getKey(userId));
+    }
+}

--- a/src/main/java/com/example/emergencyassistb4b4/auth/service/TokenService.java
+++ b/src/main/java/com/example/emergencyassistb4b4/auth/service/TokenService.java
@@ -1,0 +1,50 @@
+package com.example.emergencyassistb4b4.auth.service;
+
+import com.example.emergencyassistb4b4.auth.dto.TokenResponseDto;
+import com.example.emergencyassistb4b4.global.exception.ApiException;
+import com.example.emergencyassistb4b4.global.security.JwtUtils;
+import com.example.emergencyassistb4b4.global.status.ErrorStatus;
+import com.example.emergencyassistb4b4.user.domain.User;
+import com.example.emergencyassistb4b4.user.dto.UserResponseDto;
+import com.example.emergencyassistb4b4.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@RequiredArgsConstructor
+@Service
+public class TokenService {
+    private final JwtUtils jwtUtils;
+    private final RefreshTokenService refreshTokenService;
+    private final UserRepository userRepository;
+
+    public TokenResponseDto reissueAccessToken(String refreshToken) {
+        // 1. 리프레시 토큰 유효성 검사
+        if (!jwtUtils.validateToken(refreshToken)) {
+            throw new ApiException(ErrorStatus.INVAlID_REFRESH_TOKEN);
+        }
+        // 2. 리프레시 토큰에서 userId 추출
+        Long userId = jwtUtils.getUserId(refreshToken);
+
+        // 3. Redis에 저장된 리프레시 토큰과 일치하는지 확인
+        String saveRefresh = refreshTokenService.getRefreshToken(userId);
+        if (!refreshToken.equals(saveRefresh)) {
+           throw new ApiException(ErrorStatus.INVAlID_REFRESH_TOKEN);
+        }
+
+        // 4. 유저 정보 조회
+        User user = userRepository.findById(userId).orElseThrow( ()-> new ApiException(ErrorStatus.USER_NOT_FOUND));
+
+        // 5. 새로운 access, refresh 토큰 재발급
+        String newAccessToken = jwtUtils.generateAccessToken(UserResponseDto.from(user));
+        String newRefreshToken = jwtUtils.generateRefreshToken(UserResponseDto.from(user));
+
+        // 6. 리프레시 토큰 저장 ( 기존 것을 덮어씀)
+        refreshTokenService.saveToken(userId, newRefreshToken);
+
+        return new TokenResponseDto(newAccessToken, newRefreshToken);
+
+
+    }
+}

--- a/src/main/java/com/example/emergencyassistb4b4/global/config/RedisConfig.java
+++ b/src/main/java/com/example/emergencyassistb4b4/global/config/RedisConfig.java
@@ -1,0 +1,23 @@
+package com.example.emergencyassistb4b4.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+
+        // Key - Value 직렬화
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/example/emergencyassistb4b4/global/config/RedisConfig.java
+++ b/src/main/java/com/example/emergencyassistb4b4/global/config/RedisConfig.java
@@ -10,8 +10,8 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 public class RedisConfig {
 
     @Bean
-    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
-        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory);
 
         // Key - Value 직렬화

--- a/src/main/java/com/example/emergencyassistb4b4/global/security/CustomUserDetails.java
+++ b/src/main/java/com/example/emergencyassistb4b4/global/security/CustomUserDetails.java
@@ -1,0 +1,50 @@
+package com.example.emergencyassistb4b4.global.security;
+
+import com.example.emergencyassistb4b4.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+    private final User user;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_" + user.getUserRole().name()));
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword() != null ? user.getPassword() : "";
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/example/emergencyassistb4b4/global/security/JwtProperties.java
+++ b/src/main/java/com/example/emergencyassistb4b4/global/security/JwtProperties.java
@@ -1,0 +1,19 @@
+package com.example.emergencyassistb4b4.global.security;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+// JWT 설정파일에서 관련 값 로딩하는 클래스
+@Setter
+@Getter
+@Component
+@ConfigurationProperties("jwt")
+public class JwtProperties {
+    private String issuer; //jwt 발급자 식별자
+    private String secret; // 서명용 비밀키 Base64 인코딩 된 문자열
+
+    private long accessTokenValidity; // 액세스 토큰 유효시간
+    private long refreshTokenValidity; // 리프레시 토큰 유효시간
+}

--- a/src/main/java/com/example/emergencyassistb4b4/global/security/JwtTokenAuthenticationFilter.java
+++ b/src/main/java/com/example/emergencyassistb4b4/global/security/JwtTokenAuthenticationFilter.java
@@ -1,0 +1,60 @@
+package com.example.emergencyassistb4b4.global.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+@Log4j2
+public class JwtTokenAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtUtils jwtUtils;
+    public final static String HEADER_AUTHORIZATION = "Authorization";
+    public final static String HEADER_PREFIX = "Bearer ";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String path = request.getRequestURI();
+
+        // 필터 예외 경로 처리
+        if(isSkipPath(path)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // 요청 헤더의 Authorization 키의 값 조회
+        String authorizationHeader = request.getHeader(HEADER_AUTHORIZATION);
+        //가져온 값에서 접두사 제거
+        String token = getAccessToken(authorizationHeader);
+
+        //가져온 토큰이 유효한지 확인하고 유효한 때는 인증 정보 설정
+        if (token != null && jwtUtils.validateToken(token)) {
+            Authentication authentication = jwtUtils.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        } else {
+            log.info("No JWT token in header : 토큰이 없음!!!! ");
+        }
+        filterChain.doFilter(request, response);
+    }
+    private String getAccessToken(String authorizationHeader) {
+        if (authorizationHeader != null && authorizationHeader.startsWith(HEADER_PREFIX)) {
+            return authorizationHeader.substring(HEADER_PREFIX.length());
+
+        }
+        return null;
+    }
+    private boolean isSkipPath(String path) {
+        return path.startsWith("/api/auth/signup")
+                || path.startsWith("/api/auth/login")
+                || path.startsWith("/oauth2")
+                || path.startsWith("/api/auth/refresh");
+    }
+}

--- a/src/main/java/com/example/emergencyassistb4b4/global/security/JwtUtils.java
+++ b/src/main/java/com/example/emergencyassistb4b4/global/security/JwtUtils.java
@@ -1,0 +1,131 @@
+package com.example.emergencyassistb4b4.global.security;
+
+import com.example.emergencyassistb4b4.auth.service.RefreshTokenService;
+import com.example.emergencyassistb4b4.user.dto.UserResponseDto;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Set;
+
+// 토큰 생성, 파싱, 인증 변환 등을 처리하는 핵심
+@RequiredArgsConstructor
+@Component
+@Log4j2
+public class JwtUtils {
+
+    private final JwtProperties jwtProperties; //jwt 비밀키 등의 값을 주입받기 위한 객체
+    private final RefreshTokenService refreshTokenService;
+    /**
+     * Access Token 생성, 1시간 유효
+     */
+    public String generateRefreshToken(UserResponseDto user) {
+        return createToken(user, Duration.ofHours(1));
+    }
+    /**
+     * 사용자 정보를 기반으로 Refresh 토큰 생성 및 Redis 에 저장
+     * @param user 토큰에 포함될 사용자 정보
+     * @return  JWT 문자열
+     */
+    public String generateAccessToken(UserResponseDto user) {
+        String refreshToken = createToken(user, Duration.ofDays(14));
+        refreshTokenService.saveToken(user.getId(), refreshToken);
+        return refreshToken;
+    }
+
+
+
+    /**
+     * 만료 시간과 사용자 정보를 기반으로 JWT를 생성
+     * @param duration 토큰 만료 시각
+     * @param user 사용자 정보
+     * @return JWT 문자열
+     */
+    public String createToken(UserResponseDto user, Duration duration) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + duration.toMillis());
+        return Jwts.builder()
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE) // 헤더 typ : JWT
+                .setIssuer(jwtProperties.getIssuer()) // 내용 iss : yml 파일에서 설정한 값
+                .setIssuedAt(now) // 내용 iat : 현재 시간
+                .setExpiration(expiry) // 내용 exp : expiry 멤버 변숫값
+                .setSubject(user.getEmail()) // 내용 sub : 유저의 이메일
+                .claim("id", user.getId()) // 클레임 id : 유저 ID
+                .signWith(getSigningKey(), SignatureAlgorithm.HS256)
+                // 서명 : 비밀값과 함께 해시값을 ~ 방식으로 암호화
+                .compact();
+    }
+    private Key getSigningKey() {
+        return Keys.hmacShaKeyFor(jwtProperties.getSecret().getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * JWT 토큰 유효성 검증 메서드
+     * yml 파일에 선언한 비밀값과 함께 토큰 복호화를 진행 후 아무 에러도 발생하지 않으면 true 반환
+     * @param  token 토큰
+     * @return boolean 값
+     */
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(getSigningKey())
+                    .build()
+                    .parseClaimsJws(token).getBody();
+            return true;
+        } catch (Exception e) {
+            // 디버깅 용, 추후 삭제 예정
+            log.warn("Invalid JWT token: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * 토큰 기반으로 인증 정보를 가져오는 메서드
+     * @param token
+     * @return Authentication 토큰을 받아 인증 정보를 담은 객체 Authentication 을 반환
+     */
+    public Authentication getAuthentication(String token) {
+        Claims claims = getClaims(token); // jwt에서 claims(사용자 정보 등)를 추출
+
+        // 권한 정보 생성 ( 기본값은 ROLE_USER )
+        String role = claims.get("role", String.class);
+        Set<SimpleGrantedAuthority> authorities = Collections.singleton(new SimpleGrantedAuthority("ROLE_" + role));
+        // 사용자 정보를 기반으로 Spring Security 용 User 객체 생성
+        return new UsernamePasswordAuthenticationToken(
+                new org.springframework.security.core.userdetails.User(
+                        claims.getSubject(),"", authorities), token,authorities);
+        // subject 는 주로 이메일이나 userId로 설정, 비밀번호는 없음 (인증용 객체라 ) , 위에서 생성한 권한 정보
+        // token :  credentials (여기서는 JWT 토큰 자체)
+        // authorities : 권한 정보 다시 주입
+
+    }
+    public Long getUserId(String token) { // JWT에서 사용자 ID를 추출하는 메서드
+        Claims claims = getClaims(token); // 클레임 정보 추출
+        return claims.get("id", Long.class); // "id" 키를 Long 타입으로 가져옴
+    }
+
+    // JWT에서 Claims(페이로드 부분)를 파싱해 가져오는 내부 유틸 메서드
+    private Claims getClaims(String token) {
+        return Jwts.parserBuilder() //  JWT 파서 생성
+                .setSigningKey(getSigningKey()) // 시크릿 키 설정
+                .build()
+                .parseClaimsJws(token) // JWT 문자열을 파싱
+                .getBody(); // 클레임(body) 반환
+
+    }
+}

--- a/src/main/java/com/example/emergencyassistb4b4/global/security/WebOAuth2SecurityConfig.java
+++ b/src/main/java/com/example/emergencyassistb4b4/global/security/WebOAuth2SecurityConfig.java
@@ -1,0 +1,61 @@
+package com.example.emergencyassistb4b4.global.security;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@RequiredArgsConstructor
+@Configuration
+public class WebOAuth2SecurityConfig {
+
+    private final JwtUtils jwtUtils;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/static/**").permitAll()
+                        .requestMatchers(
+                                "/static/**",
+                                "/api/auth/signup",
+                                "/api/auth/login",
+                                "/oauth2/**",
+                                "/api/refresh"
+
+                        ).permitAll()
+                        .requestMatchers("/api/**").authenticated()
+                        .anyRequest().authenticated()
+                )
+                .csrf(AbstractHttpConfigurer::disable) // CSRF 보호 비활성화 (JWT 기반에선 불필요)
+                .httpBasic(AbstractHttpConfigurer::disable) // HTTP BASIC 비활성화
+                .formLogin(AbstractHttpConfigurer::disable) // 기본 폼 사용 X
+                .logout(AbstractHttpConfigurer::disable) // 로그아웃 비활성화
+                .sessionManagement(management -> management.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) //세션 사용안함
+                .addFilterBefore(new JwtTokenAuthenticationFilter(jwtUtils), UsernamePasswordAuthenticationFilter.class) //JWT 필터 등록
+
+
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint((request, response, authException) -> {
+                            response.setStatus(HttpServletResponse.SC_ACCEPTED);
+                            response.getWriter().write("Unauthorized");
+                        }))
+                .build();
+    }
+
+    @Bean
+    public JwtTokenAuthenticationFilter jwtTokenAuthenticationFilter() {
+        return new JwtTokenAuthenticationFilter(jwtUtils);
+    }
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+}

--- a/src/main/java/com/example/emergencyassistb4b4/global/status/ErrorStatus.java
+++ b/src/main/java/com/example/emergencyassistb4b4/global/status/ErrorStatus.java
@@ -9,6 +9,31 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ErrorStatus implements BaseErrorCode {
 
+    // 인증 및 인가
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AU001","인증이 필요합니다."),
+    INVAlID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "AU002","유효하지 않은 액세스 토큰입니다."),
+    EXPIRED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "AU003","액세스 토큰이 만료되었습니다."),
+    INVAlID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AU004","유효하지 않은 리프레시 토큰입니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AU005","리프레시 토큰을 찾을 수 없습니다."),
+    TOKEN_USER_MISMATCH(HttpStatus.UNAUTHORIZED, "AU006","토큰의 사용자 정보가 일치하지 않습니다."),
+
+
+    //회원가입 및 로그인
+    DUPLICATED_EMAIL(HttpStatus.CONFLICT, "U001", "이미 존재하는 이메일입니다."),
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "U002", "비밀번호가 일치하지 않습니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U003", "해당 사용자를 찾을 수 없습니다."),
+    OAUTH_PROVIDER_MISMATCH(HttpStatus.BAD_REQUEST, "U004", "다른 OAuth 제공자로 가입된 계정입니다."),
+    OAUTH_LOGIN_ONLY(HttpStatus.BAD_REQUEST, "U005", "소셜 로그인으로 가입된 계정입니다. 자체 로그인 불가합니다."),
+    SELF_LOGIN_ONLY(HttpStatus.BAD_REQUEST, "U006", "자체 로그인으로 가입된 계정입니다. 소셜 로그인 불가합니다."),
+    SIGNUP_STRATEGY_NOT_FOUND(HttpStatus.BAD_REQUEST, "U007", " 지원하지 않는 회원가입 방식입니다."),
+    LOGIN_STRATEGY_NOT_FOUND(HttpStatus.BAD_REQUEST, "U008", " 지원하지 않는 로그인 방식입니다."),
+    // 로그아웃
+    LOGOUT_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "U001", "로그아웃 처리에 실패했습니다."),
+
+    // Redis
+    REDIS_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "R001", "Redis 에 토큰 저장 실패"),
+    REDIS_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "R002", "Redis 에서 토큰 삭제 실패"),
+
     CUSTOM_ERROR_STATUS(HttpStatus.INTERNAL_SERVER_ERROR, "C001", "Custom Error");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/emergencyassistb4b4/user/dto/UserResponseDto.java
+++ b/src/main/java/com/example/emergencyassistb4b4/user/dto/UserResponseDto.java
@@ -1,0 +1,16 @@
+package com.example.emergencyassistb4b4.user.dto;
+
+import com.example.emergencyassistb4b4.user.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserResponseDto {
+    private Long id;
+    private String email;
+
+    public static UserResponseDto from(User user) {
+        return new UserResponseDto(user.getId(), user.getEmail());
+    }
+}

--- a/src/main/java/com/example/emergencyassistb4b4/user/repository/UserRepository.java
+++ b/src/main/java/com/example/emergencyassistb4b4/user/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.example.emergencyassistb4b4.user.repository;
+
+import com.example.emergencyassistb4b4.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+    boolean existsByEmail(String email);
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,12 +18,11 @@ spring:
       hibernate:
         format_sql: true
   jwt:
-    token:
-      access:
-        minute: 15
-      refresh:
-        minute: 20160
+    issuer: my-app
     secret: ${JWT_SECRET_KEY}
+    access-token-validity: 900000      # 15분
+    refresh-token-validity: 1209600000 # 14일
+
   data:
     redis:
       host: ${REDIS_HOST:127.0.0.1}
@@ -50,3 +49,36 @@ logging:
     org.springframework.data.redis: WARN
     org.springframework.kafka: INFO
     com.example.disaster: DEBUG
+
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+            redirect-uri: "http://localhost:8080/api/auth/oauth2/google"
+            scope:
+              - profile
+              - email
+            client-name: Google
+
+          kakao:
+            client-id: ${KAKAO_CLIENT_ID}
+            redirect-uri: http://localhost:8080/api/auth/oauth2/kakao
+            client-authentication-method: POST
+            authorization-grant-type: authorization_code
+            scope:
+              - profile_nickname
+              - account_email
+            client-name: Kakao
+            provider: kakao
+        provider:
+          kakao:
+            authorization-uri: ${KAKAO_AUTH_URI}
+            token-uri: ${KAKAO_TOKEN_URI}
+            user-info-uri: ${KAKAO_USER_INFO_URI}
+            user-name-attribute: id
+
+  config:
+    import: classpath:/.env


### PR DESCRIPTION
## 📌 JWT 인증 기능 구현
- Closes #11   <!-- 연결된 이슈 번호 기재 -->

---

## ✨ 기능 요약
Spring Security와 JWT 기반 인증 구조의 기본 설정을 완료하고, 이후 회원가입/로그인 기능의 기반을 마련합니다.
<html><head></head><body>

항목 | 내용
-- | --
🆕 기능명 | JWT 인증 및 리프레시 토큰 기반 재발급 기능 구현
🔍 목적 | 세션 없는 토큰 기반 인증과 안정적인 AccessToken 재발급 처리
🛠️ 변경사항 | JWT 필터/유틸, 보안 설정, Redis 설정, 토큰 재발급 서비스 포함 전체 인증 흐름 구현

</body></html>

---

## 📝 상세 내역
<html><head></head><body>

번호 | 내용
-- | --
1️⃣ | JwtProperties 생성 – JWT 관련 설정값 주입
2️⃣ | JwtUtils 클래스 – Access/Refresh Token 발급 및 검증 메서드 구현
3️⃣ | JwtAuthenticationFilter 구현 – 요청 시 JWT 검증 및 SecurityContext 저장
4️⃣ | SecurityFilterChain 설정 – csrf, session 등 비활성화, JWT 필터 등록, 인증/비인증 경로 분리
5️⃣ | /api/** 인증 적용, /api/auth/** 예외 처리 설정
6️⃣ | BCryptPasswordEncoder Bean 등록
7️⃣ | RedisConfig 작성 – RedisTemplate 설정 및 연결
8️⃣ | RefreshTokenService 구현 – Redis를 통한 토큰 저장, 조회, 삭제 처리
9️⃣ | TokenResponseDto – AccessToken과 RefreshToken 구조 정의
🔟 | TokenService 구현 – 유효한 리프레시 토큰으로 AccessToken/RefreshToken 재발급 로직
 

---

## ✅ 테스트 체크리스트
 
- [ ] JWT 발급/검증 정상 동작
- [ ] JWT 인증 필터가 유효한 토큰을 통해 SecurityContext 저장하는지 확인
- [ ] Redis에 리프레시 토큰 저장 및 갱신 흐름 확인
- [ ] 유효한 리프레시 토큰으로 토큰 재발급 정상 처리
- [ ] 인증 필수/예외 경로가 Security 설정에 따라 정확하게 작동하는지 확인
 

## 📸 포스트맨 캡처 사진

## 🙋‍♀️ 리뷰어 참고사항
- JwtUtils는 기존 JwtTokenProvider의 리팩토링 버전입니다. 메서드 구성 및 책임 분리에 중점을 두었습니다.
- RefreshTokenService는 RedisTemplate을 통해 리프레시 토큰을 키-값 구조로 관리하며, 토큰 만료 시간은 JWT 설정과 일치시켰습니다.
- TokenService는 기존 토큰 유효성 확인 후 새로운 토큰 세트를 발급하며, 이전 리프레시 토큰은 삭제됩니다.
- 전체 인증 플로우가 자연스럽게 이어지는지에 대한 흐름 리뷰도 부탁드립니다.
- 아직 회원가입/로그인/Oauth 구성 전입니다.(파일 옮기기만 하면 돼서) 이어서 이슈파고 피알 올리겠습니다.
- 테스트 코드 작성 중입니다 
