### PR TITLE
Feat/참가 정보 조회 추가

### DIFF
--- a/src/main/java/com/example/emergencyassistb4b4/volunteer/controller/VolunteerJoinController.java
+++ b/src/main/java/com/example/emergencyassistb4b4/volunteer/controller/VolunteerJoinController.java
@@ -4,6 +4,7 @@ import com.example.emergencyassistb4b4.global.response.ApiResponse;
 import com.example.emergencyassistb4b4.global.security.CustomUserDetails;
 import com.example.emergencyassistb4b4.global.status.SuccessStatus;
 import com.example.emergencyassistb4b4.volunteer.dto.Join.CheckinStatusRequest;
+import com.example.emergencyassistb4b4.volunteer.dto.Join.VolunteerParticipationResponse;
 import com.example.emergencyassistb4b4.volunteer.service.VolunteerJoinService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +12,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -39,6 +42,15 @@ public class VolunteerJoinController {
     ) {
         volunteerJoinService.cancelJoin(participantId, request, userDetails.getUser().getId());
         return ApiResponse.onSuccess(SuccessStatus.VOLUNTEER_SUCCESS, null);
+    }
+
+    @PreAuthorize("hasRole('IND')")
+    @GetMapping("/volunteer-participants/my")
+    public ResponseEntity<ApiResponse<List<VolunteerParticipationResponse>>> getMyParticipationList(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        List<VolunteerParticipationResponse> list = volunteerJoinService.getMyParticipation(userDetails.getUser().getId());
+        return ApiResponse.onSuccess(SuccessStatus.VOLUNTEER_SUCCESS, list);
     }
 
 }

--- a/src/main/java/com/example/emergencyassistb4b4/volunteer/dto/Join/VolunteerParticipationResponse.java
+++ b/src/main/java/com/example/emergencyassistb4b4/volunteer/dto/Join/VolunteerParticipationResponse.java
@@ -1,0 +1,36 @@
+package com.example.emergencyassistb4b4.volunteer.dto.Join;
+
+import com.example.emergencyassistb4b4.volunteer.domain.VolunteerParticipant;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class VolunteerParticipationResponse {
+
+    private Long participantId;
+    private Long postId;
+    private String postTitle;
+    private int teamNumber;
+    private String status;
+    private LocalDateTime joinedAt;
+    private LocalDateTime checkinStart;
+    private LocalDateTime checkinEnd;
+    private String placeName;
+
+    public static VolunteerParticipationResponse from(VolunteerParticipant vp) {
+        return VolunteerParticipationResponse.builder()
+                .participantId(vp.getId())
+                .postId(vp.getVolunteerTeam().getPost().getId())
+                .postTitle(vp.getVolunteerTeam().getPost().getTitle())
+                .teamNumber(vp.getVolunteerTeam().getTeamNumber())
+                .status(vp.getCheckinStatus().name())
+                .joinedAt(vp.getJoinedAt())
+                .checkinStart(vp.getVolunteerTeam().getPost().getAttendancePolicy().getCheckinStart())
+                .checkinEnd(vp.getVolunteerTeam().getPost().getAttendancePolicy().getCheckinEnd())
+                .placeName(vp.getVolunteerTeam().getPost().getLocation().getPlaceName())
+                .build();
+    }
+}

--- a/src/main/java/com/example/emergencyassistb4b4/volunteer/enums/CheckinStatus.java
+++ b/src/main/java/com/example/emergencyassistb4b4/volunteer/enums/CheckinStatus.java
@@ -2,8 +2,6 @@ package com.example.emergencyassistb4b4.volunteer.enums;
 
 public enum CheckinStatus {
     PARTICIPATED,
-//    CHECKING,
-//    CHECKED,
     CANCELLED,
     BLACKLISTED,
     PRESENT,   // 출석

--- a/src/main/java/com/example/emergencyassistb4b4/volunteer/infra/redis/service/TTLRedisService.java
+++ b/src/main/java/com/example/emergencyassistb4b4/volunteer/infra/redis/service/TTLRedisService.java
@@ -1,0 +1,47 @@
+package com.example.emergencyassistb4b4.volunteer.infra.redis.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class TTLRedisService {
+
+    private final StringRedisTemplate redisTemplate;
+
+    private static final String COUNT_KEY_FORMAT = "team:%d:count";
+    private static final String USERS_KEY_FORMAT = "team:%d:users";
+
+    /**
+     * TTL 설정 - Duration
+     */
+    public void setTeamKeyTTL(Long teamId, Duration duration) {
+        setTeamKeyTTL(teamId, duration.getSeconds(), TimeUnit.SECONDS);
+    }
+
+    /**
+     * TTL 설정 - 직접 시간 단위
+     */
+    public void setTeamKeyTTL(Long teamId, long duration, TimeUnit unit) {
+        String countKey = String.format(COUNT_KEY_FORMAT, teamId);
+        String usersKey = String.format(USERS_KEY_FORMAT, teamId);
+
+        redisTemplate.expire(countKey, duration, unit);
+        redisTemplate.expire(usersKey, duration, unit);
+    }
+
+    /**
+     * 팀 키 삭제
+     */
+    public void deleteTeamKeys(Long teamId) {
+        String countKey = String.format(COUNT_KEY_FORMAT, teamId);
+        String usersKey = String.format(USERS_KEY_FORMAT, teamId);
+
+        redisTemplate.delete(countKey);
+        redisTemplate.delete(usersKey);
+    }
+}

--- a/src/main/java/com/example/emergencyassistb4b4/volunteer/infra/redis/service/TeamParticipationRedisService.java
+++ b/src/main/java/com/example/emergencyassistb4b4/volunteer/infra/redis/service/TeamParticipationRedisService.java
@@ -8,6 +8,8 @@ import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -17,12 +19,13 @@ public class TeamParticipationRedisService {
     private final RedisTemplate<String, String> redisTemplate;
     private final DefaultRedisScript<Long> joinTeamScript;
     private final DefaultRedisScript<Long> cancelJoinScript;
+    private final TTLRedisService ttlRedisService;
 
     private static final String COUNT_KEY_FORMAT = "team:%d:count";
     private static final String USERS_KEY_FORMAT = "team:%d:users";
 
     // 참가 : 현재 인원 +
-    public void tryJoinTeam(Long teamId, Long userId, int maxCapacity) {
+    public void tryJoinTeam(Long teamId, Long userId, int maxCapacity, LocalDateTime checkinEnd) {
         String countKey = String.format(COUNT_KEY_FORMAT, teamId);
         String usersKey = String.format(USERS_KEY_FORMAT, teamId);
 
@@ -39,7 +42,10 @@ public class TeamParticipationRedisService {
         }
 
         switch (result.intValue()) {
-            case 1 -> {} // 성공
+            case 1 -> {
+                Duration ttl = Duration.between(LocalDateTime.now(), checkinEnd.plusHours(1));
+                ttlRedisService.setTeamKeyTTL(teamId, ttl);
+            }
             case 0, -1 -> throw new ApiException(ErrorStatus.VOLUNTEER_CONFLICT);
             default -> throw new ApiException(ErrorStatus.VOLUNTEER_BAD_REQUEST);
         }

--- a/src/main/java/com/example/emergencyassistb4b4/volunteer/repository/VolunteerParticipantRepository.java
+++ b/src/main/java/com/example/emergencyassistb4b4/volunteer/repository/VolunteerParticipantRepository.java
@@ -28,13 +28,32 @@ public interface VolunteerParticipantRepository extends JpaRepository<VolunteerP
     Optional<Long> findPostIdByParticipantId(@Param("participantId") Long participantId);
 
     @Query("""
-    SELECT vp
-    FROM VolunteerParticipant vp
-    JOIN FETCH vp.volunteerTeam t
-    JOIN FETCH t.post p
-    JOIN FETCH p.location l
-    JOIN FETCH p.attendancePolicy ap
-    WHERE vp.id = :volunteerId
-""")
+        SELECT vp
+        FROM VolunteerParticipant vp
+        JOIN FETCH vp.volunteerTeam t
+        JOIN FETCH t.post p
+        JOIN FETCH p.location l
+        JOIN FETCH p.attendancePolicy ap
+        WHERE vp.id = :volunteerId
+    """)
     Optional<VolunteerParticipant> findWithTeamAndPolicyById(@Param("volunteerId") Long volunteerId);
+
+    @Query("""
+        SELECT COUNT(vp) > 0
+        FROM VolunteerParticipant vp
+        WHERE vp.user.id = :userId
+          AND vp.checkinStatus = 'PARTICIPATED'
+    """)
+    boolean existsActiveParticipation(@Param("userId") Long userId);
+
+    @Query("""
+        SELECT vp FROM VolunteerParticipant vp
+        JOIN FETCH vp.volunteerTeam t
+        JOIN FETCH t.post p
+        JOIN FETCH p.attendancePolicy ap
+        JOIN FETCH p.location l
+        WHERE vp.user.id = :userId
+    """)
+    List<VolunteerParticipant> findAllByUserIdWithPostAndTeam(@Param("userId") Long userId);
+
 }

--- a/src/main/java/com/example/emergencyassistb4b4/volunteer/service/VolunteerAttendanceService.java
+++ b/src/main/java/com/example/emergencyassistb4b4/volunteer/service/VolunteerAttendanceService.java
@@ -1,4 +1,0 @@
-package com.example.emergencyassistb4b4.volunteer.service;
-
-public class VolunteerAttendanceService {
-}

--- a/src/main/java/com/example/emergencyassistb4b4/volunteer/service/VolunteerJoinService.java
+++ b/src/main/java/com/example/emergencyassistb4b4/volunteer/service/VolunteerJoinService.java
@@ -9,16 +9,20 @@ import com.example.emergencyassistb4b4.volunteer.domain.VolunteerParticipant;
 import com.example.emergencyassistb4b4.volunteer.domain.VolunteerTeam;
 import com.example.emergencyassistb4b4.volunteer.dto.Join.CheckinPeriodDto;
 import com.example.emergencyassistb4b4.volunteer.dto.Join.CheckinStatusRequest;
+import com.example.emergencyassistb4b4.volunteer.dto.Join.VolunteerParticipationResponse;
 import com.example.emergencyassistb4b4.volunteer.infra.redis.service.TeamParticipationRedisService;
 import com.example.emergencyassistb4b4.volunteer.repository.VolunteerParticipantRepository;
 import com.example.emergencyassistb4b4.volunteer.repository.PostRepository;
 import com.example.emergencyassistb4b4.volunteer.repository.VolunteerTeamRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class VolunteerJoinService {
@@ -31,11 +35,17 @@ public class VolunteerJoinService {
     private final TrackingSocketHandler trackingSocketHandler;
     private final TrackingScheduleEventListener eventListener;
 
-    LocalDateTime now = LocalDateTime.now();
 
     // 팀 참가
     @Transactional
     public void joinTeam(Long postId, int teamNumber, Long userId ) {
+        LocalDateTime now = LocalDateTime.now();
+
+        // 참가 중인 경우 X
+        if (participantRepository.existsActiveParticipation(userId)) {
+            throw new ApiException(ErrorStatus.VOLUNTEER_BAD_REQUEST);
+        }
+
         // 출석 시간 지난 경우 X
         CheckinPeriodDto period = postRepository.findCheckinPeriodByPostId(postId)
                 .orElseThrow(() -> new ApiException(ErrorStatus.VOLUNTEER_BAD_REQUEST));
@@ -48,8 +58,8 @@ public class VolunteerJoinService {
         VolunteerTeam team = teamRepository.findByPost_IdAndTeamNumber(postId, teamNumber)
                 .orElseThrow(() -> new ApiException(ErrorStatus.VOLUNTEER_NOT_FOUND));
 
-        // 현재 인원 +
-        teamParticipationRedisService.tryJoinTeam(team.getId(), userId, team.getMaxCapacity());
+        // 현재 인원 + + TTL 설정 (checkinEnd 전달)
+        teamParticipationRedisService.tryJoinTeam(team.getId(), userId, team.getMaxCapacity(), period.checkinEnd());
 
         // 팀원 DB 저장
         participantService.joinSave(userId, team.getId());
@@ -58,6 +68,8 @@ public class VolunteerJoinService {
     // 팀 참가 취소
     @Transactional
     public void cancelJoin(Long participantId, CheckinStatusRequest request, Long userId) {
+        LocalDateTime now = LocalDateTime.now();
+
         // 참가자 존재 + 내 것인지 확인
         VolunteerParticipant participant = participantRepository.findByIdAndUserId(participantId, userId)
                 .orElseThrow(() -> new ApiException(ErrorStatus.VOLUNTEER_FORBIDDEN));
@@ -69,6 +81,14 @@ public class VolunteerJoinService {
         // 출석 시간 < 취소 X < 출석 마감 시간
         CheckinPeriodDto period = postRepository.findCheckinPeriodByPostId(postId)
                 .orElseThrow(() -> new ApiException(ErrorStatus.VOLUNTEER_NOT_FOUND));
+        log.debug("현재 시간 now          : {}", now);
+        log.debug("출석 시작 checkinStart : {}", period.checkinStart());
+        log.debug("출석 종료 checkinEnd   : {}", period.checkinEnd());
+        log.debug("조건 평가 결과         : isAfterStart={}, isBeforeEnd={}, 전체조건={}",
+                now.isAfter(period.checkinStart()),
+                now.isBefore(period.checkinEnd()),
+                now.isAfter(period.checkinStart()) && now.isBefore(period.checkinEnd())
+        );
 
         if(now.isAfter(period.checkinStart()) && now.isBefore(period.checkinEnd())) {
             throw new ApiException(ErrorStatus.VOLUNTEER_BAD_REQUEST);
@@ -86,4 +106,12 @@ public class VolunteerJoinService {
         eventListener.handleTrackingScheduleEvent(new TrackingScheduleEvent(participant.getVolunteerTeam().getId()));
     }
 
+    // 참가 목록
+    @Transactional(readOnly = true)
+    public List<VolunteerParticipationResponse> getMyParticipation(Long userId) {
+        List<VolunteerParticipant> participants = participantRepository.findAllByUserIdWithPostAndTeam(userId);
+        return participants.stream()
+                .map(VolunteerParticipationResponse::from)
+                .toList();
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,7 +23,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: create
     show-sql: true
     properties:
       hibernate:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,6 +21,12 @@ spring:
     password: ${POSTGRE_PASSWORD}
     driver-class-name: org.postgresql.Driver
 
+  hikari:
+    maximum-pool-size: 30     # 최대 커넥션 수
+    minimum-idle: 10          # 최소 커넥션 수
+    idle-timeout: 30000       # 비활성 커넥션 유지 시간 (ms)
+    connection-timeout: 20000 # 커넥션을 얻기 위한 최대 대기 시간 (ms)
+
   jpa:
     hibernate:
       ddl-auto: create


### PR DESCRIPTION
📌 개요
- 사용자가 자신의 자원봉사 참가 내역을 확인할 수 있는 API를 추가하였습니다.

✅ 주요 변경 사항
- VolunteerJoinController에 /volunteer-participants/my API 추가

- VolunteerJoinService에 getMyParticipation() 메서드 구현

- VolunteerParticipationResponse DTO 생성

- Redis TTL 관리용 TTLRedisService 추가

- VolunteerAttendanceService (사용하지 않아 삭제)

📦 변경된 파일
- VolunteerJoinController.java

- VolunteerJoinService.java

- VolunteerParticipantRepository.java

- VolunteerParticipationResponse.java ✅ (신규)

- TTLRedisService.java ✅ (신규)

- application.yml (필요 시 Redis TTL 설정 반영)

- 기타 리팩토링 및 불필요 파일 삭제

🧪 테스트
- 참가 후 /my API로 참가 목록 정상 조회 확인

- 취소 시 상태 CANCELLED로 변경됨 확인

- Redis TTL 설정으로 참가 정보 자동 만료됨 확인

🔁 병합 대상
기준 브랜치: dev/backend

작업 브랜치: fix-VolunteerJoin